### PR TITLE
Smooth out development hiccups 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # misc
 .DS_Store
 *.pem
+.turbo
 
 # debug
 npm-debug.log*
@@ -29,6 +30,11 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+
+# config files
+micro.yaml
+micro
+!example/*
 
 *.tsbuildinfo
 dist

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ A vanity file sharing service with support for ShareX. You can see a preview at 
 
 ## development
 
-You can pull the repo and then `pnpm install`, after that everything should be good to go. You can start the `packages/api`/`packages/web` with `pnpm watch`.
+1. Pull the repo and then `pnpm install`.
+2. Run `docker compose up -d` to start postgres and minio development instances.
+3. Copy `micro.example.yaml` to `micro.yaml`, change any options relevant to your environment.
+5. Then, you can start the `packages/api`/`packages/web` with `pnpm watch`. Keep a look out for a `InviteService` log entry, which will direct you to an invite to then create the initial account.
 
 ## todo
 

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: micro_postgres
     restart: unless-stopped
     ports:
-      - 127.0.0.1:5433:5432
+      - 127.0.0.1:5432:5432
     environment:
       - POSTGRES_USER=micro
       - POSTGRES_PASSWORD=youshallnotpass

--- a/micro.example.yaml
+++ b/micro.example.yaml
@@ -3,7 +3,7 @@
 # remove the .yaml extension or change it to .json to use JSON-with-comments
 # ref: https://github.com/sylv/venera#sources
 
-databaseUrl: postgresql://micro:youshallnotpass@postgres/micro
+databaseUrl: postgresql://micro:youshallnotpass@127.0.0.1/micro
 
 # EXTREMELY IMPORTANT
 # this is the secret used to sign json web tokens. this *must* be a secure, random string that no one else has.
@@ -16,7 +16,7 @@ secret: YOU_SHALL_NOT_PASS
 inquiries: admin@example.com
 
 # where to store files, can be relative to the cwd or absolute.
-storagePath: /data
+storagePath: data
 
 # string formatted maximum file upload size. 
 uploadLimit: 10MB
@@ -45,16 +45,16 @@ restrictFilesToHost: true
 
 hosts:
     # the first host in the list is the default host
-  - url: https://i.example.com
+  - url: http://127.0.0.1
 
     # {{username}} will become the users name when they use this host
-  - url: https://{{username}}.example.com
+  # - url: https://{{username}}.example.com
 
-  - url: https://i.example.net
+  # - url: https://i.example.net
     # redirect when users go to this hosts url without a file
-    redirect: https://example.net 
+    # redirect: https://example.net 
     # only allow users with the "admin" tag to use this host
-    tags: ["admin"]
+    # tags: ["admin"]
 
 
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,7 +13,7 @@
     "build": "tsc --noEmit && tsup",
     "start": "node dist/main.js",
     "test": "vitest run",
-    "watch": "tsup --watch --onSuccess \"node dist/main.js\"",
+    "watch": "NODE_ENV=development tsup --watch --onSuccess \"node dist/main.js\"",
     "mikro-orm": "tsup --no-dts --silent && MIKRO_ORM_MIGRATIONS_PATH=src/migrations mikro-orm"
   },
   "dependencies": {

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -106,7 +106,7 @@ if (rootHost.isWildcard) {
 }
 
 const disallowed = new Set(["youshallnotpass", "you_shall_not_pass", "secret", "test"]);
-if (disallowed.has(config.secret.toLowerCase())) {
+if (process.env.NODE_ENV !== "development" && disallowed.has(config.secret.toLowerCase())) {
   const token = randomBytes(24).toString("hex");
   throw new Error(
     dedent`

--- a/packages/web/src/pages/upload/+Page.tsx
+++ b/packages/web/src/pages/upload/+Page.tsx
@@ -133,7 +133,7 @@ export const Page: FC = () => {
       <Container center>
         <Card className="flex flex-col items-center justify-center w-full h-2/4">
           <h1 className="mb-4 text-2xl">{file.name}</h1>
-          <div className="flex items-center justify-center">
+          <div className="flex items-center justify-center gap-4">
             <Select
               prefix="Host"
               className="shrink-0 w-40 mr-2"


### PR DESCRIPTION
- added micro config files `.gitignore`, this excludes the example directory, also added the required `uploadLimit` option to the examples. (happy 11 month anniversary to #46)
- added a little more detail to the dev section of the main readme, these instructions are also included in the installation instructions, but this should make it more accessible
- fixed dev container ports and development environments now ignore disallowed config secrets 